### PR TITLE
docs(seo): Improve GitHub + external SEO and conversion (README, demo meta, community files)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+name: Bug report
+description: Create a report to help us improve
+labels: [bug]
+body:
+  - type: checkboxes
+    attributes:
+      label: Pre-check
+      options:
+        - label: I searched existing issues and docs
+          required: true
+        - label: I am using the latest release
+          required: true
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Selected text: "..."
+        2. Clicked PopClip icon
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+  - type: textarea
+    attributes:
+      label: Actual behavior
+  - type: input
+    attributes:
+      label: macOS version
+      placeholder: e.g., 14.5
+  - type: input
+    attributes:
+      label: PopClip version
+      placeholder: e.g., 2024.5
+  - type: input
+    attributes:
+      label: LLMCal version
+      placeholder: e.g., v2.0.0
+  - type: textarea
+    attributes:
+      label: Additional context / logs (sanitize secrets)
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Ideas (Discussions)
+    url: https://github.com/cafferychen777/LLMCal/discussions
+    about: Ask questions, share ideas, and get help
+  - name: Security reports
+    url: https://github.com/cafferychen777/LLMCal/security/advisories
+    about: Please report security vulnerabilities via private advisory
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest an idea for this project
+labels: [enhancement]
+body:
+  - type: checkboxes
+    attributes:
+      label: Pre-check
+      options:
+        - label: I searched existing issues and docs
+          required: true
+  - type: textarea
+    attributes:
+      label: Problem to solve
+      description: What problem are you trying to solve?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposed solution / UX
+      description: Describe the desired behavior or UX
+  - type: textarea
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    attributes:
+      label: Additional context / examples
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+Describe the changes and the motivation.
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] CI/CD / tooling
+
+## Related issues
+Fixes #
+
+## How to test
+Steps, commands, or screenshots.
+
+## Checklist
+- [ ] Tests added/updated (if applicable)
+- [ ] Docs updated (README/docs/CHANGELOG)
+- [ ] No secrets or credentials in code or logs
+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+title: "LLMCal: AI-Powered Calendar Event Creator for PopClip"
+authors:
+  - family-names: Yang
+    given-names: Chen
+version: "1.0.0"
+date-released: 2024-12-01
+repository-code: "https://github.com/cafferychen777/LLMCal"
+license: "AGPL-3.0-only WITH Commons-Clause"
+keywords: [PopClip, macOS, Calendar, AI, NLP, Anthropic, Claude, Productivity]
+abstract: "LLMCal is a PopClip extension that turns natural language into calendar events with multilingual support, recurring events, reminders, and meeting link parsing."
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming environment for all. This Code of Conduct applies to all project spaces and participants.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Unacceptable behaviors include:
+- Harassment, discrimination, or exclusionary behavior
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others’ private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards. Appropriate and fair corrective action may be taken in response to any behavior deemed inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when an individual is representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening a private security advisory or contacting the maintainers.
+
+- Report a vulnerability or sensitive issue: GitHub → Security → Advisories
+- Otherwise, open an issue with the appropriate template
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# LLMCal — PopClip AI Calendar Extension
+
 <div align="center">
 
 **[English](#english)** | **[中文](#chinese)** | **[Español](#español)** | **[Français](#français)** | **[Deutsch](#deutsch)** | **[日本語](#japanese)**
@@ -7,12 +9,22 @@
 # English
 
 <div align="center">
-  <img src="assets/logo.png" alt="LLMCal Logo" width="200">
-  
+  <img src="assets/logo.png" alt="LLMCal Logo (PopClip AI Calendar Extension)" width="200">
+
   <h1>LLMCal - AI-Powered Calendar Event Creator for PopClip</h1>
-  
+
+  <!-- Project badges -->
   <a href="https://cafferychen777.github.io/LLMCal/" target="_blank">
-    <img src="https://img.shields.io/badge/Demo-Live-brightgreen" alt="Live Demo">
+    <img src="https://img.shields.io/badge/Demo-Live-brightgreen" alt="Live Demo (GitHub Pages)">
+  </a>
+  <a href="https://github.com/cafferychen777/LLMCal/actions/workflows/test.yml">
+    <img src="https://github.com/cafferychen777/LLMCal/actions/workflows/test.yml/badge.svg" alt="CI: Test Suite">
+  </a>
+  <a href="https://github.com/cafferychen777/LLMCal/actions/workflows/e2e.yml">
+    <img src="https://github.com/cafferychen777/LLMCal/actions/workflows/e2e.yml/badge.svg" alt="CI: E2E Tests">
+  </a>
+  <a href="https://github.com/cafferychen777/LLMCal/actions/workflows/deploy.yml">
+    <img src="https://github.com/cafferychen777/LLMCal/actions/workflows/deploy.yml/badge.svg" alt="Deploy Demo (Pages)">
   </a>
   <a href="https://github.com/cafferychen777/LLMCal/stargazers">
     <img src="https://img.shields.io/github/stars/cafferychen777/LLMCal" alt="GitHub stars">
@@ -30,11 +42,26 @@
     <img src="https://img.shields.io/github/v/release/cafferychen777/LLMCal" alt="GitHub release">
   </a>
   <a href="https://www.popclip.app/">
-    <img src="https://img.shields.io/badge/Platform-PopClip-orange" alt="Platform">
+    <img src="https://img.shields.io/badge/Platform-PopClip-orange" alt="Platform: PopClip (macOS)">
   </a>
 </div>
 
 LLMCal is a powerful PopClip extension that uses AI to convert selected text into calendar events. It understands natural language descriptions and automatically creates events with proper titles, times, locations, meeting links, and reminders.
+## Table of Contents
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Example Inputs](#example-inputs)
+- [Google Calendar Integration](#google-calendar-integration)
+- [Privacy & Security](#privacy--security)
+- [Why LLMCal? (Use Cases & Alternatives)](#why-llmcal-use-cases--alternatives)
+- [Quick Start Guide](#quick-start-guide)
+- [Advanced Configuration](#advanced-configuration)
+- [Troubleshooting](#troubleshooting)
+- [FAQ](#faq)
+- [Comparison to Alternatives](#comparison-to-alternatives)
+- [Community & Support](#community--support)
+
 
 ## Features
 
@@ -136,6 +163,28 @@ While LLMCal currently works directly with Apple Calendar, you can still use it 
 3. **Troubleshooting**
    - If events aren't syncing, check your internet connection
    - Ensure your Google account is properly connected in System Settings
+## FAQ
+
+- Does it work with Google Calendar?
+  - Yes. Connect Google account to Apple Calendar on macOS; events created via LLMCal sync to Google Calendar.
+- Does it detect recurring events and reminders?
+  - Yes. It parses common recurring patterns and reminders from natural language.
+- Does it support Zoom/Teams/Meet links?
+  - Yes. Meeting URLs in the selected text are extracted and added to the event.
+
+## Comparison to Alternatives
+
+- PopClip + LLMCal vs full calendar apps: much faster for “highlight text → create event”, zero window/context switching
+- Native calendar parsing: typically limited; LLMCal leverages AI (Claude) for more robust extraction (attendees, locations, time zones)
+- Browser extensions: require browser context; LLMCal works system-wide on macOS via PopClip
+
+## Community & Support
+
+- Issues: use the templates to report bugs and request features
+- Discussions: share ideas and Q&A in GitHub Discussions
+- Security: report privately via Security Advisory
+- Docs: see docs/INSTALLATION.md, docs/DEVELOPMENT.md, docs/TROUBLESHOOTING.md, and CONTRIBUTING.md
+
    - Try removing and re-adding your Google account if issues persist
    - Check if you've granted necessary permissions to both calendars
 
@@ -145,6 +194,12 @@ While LLMCal currently works directly with Apple Calendar, you can still use it 
 - No event data is stored or transmitted except to create the calendar event
 - All natural language processing is done through Claude AI
 - The extension only requires necessary permissions: text selection and calendar access
+
+## Why LLMCal? (Use Cases & Alternatives)
+
+- Rapidly create Apple/Google Calendar events on macOS from highlighted text
+- Reliable parsing of reminders, recurring rules (RRULE), locations, and meeting links (Zoom/Teams/Meet)
+- Lightweight PopClip workflow vs. full-blown calendar apps or browser extensions
 
 ## Quick Start Guide
 
@@ -183,7 +238,7 @@ LLMCal automatically detects your system language and supports:
 
 #### 🔑 API Key Problems
 **Issue**: "Invalid API key" error
-**Solution**: 
+**Solution**:
 1. Verify your API key at [console.anthropic.com](https://console.anthropic.com/)
 2. Check for extra spaces or characters
 3. Restart PopClip after updating
@@ -226,9 +281,9 @@ This project is licensed under the GNU Affero General Public License Version 3 (
 
 <div align="center">
   <img src="assets/logo.png" alt="LLMCal Logo" width="200">
-  
+
   <h1>LLMCal - 基于 AI 的 PopClip 日历事件创建工具</h1>
-  
+
   <a href="https://cafferychen777.github.io/LLMCal/" target="_blank">
     <img src="https://img.shields.io/badge/演示-查看-brightgreen" alt="在线演示">
   </a>
@@ -379,9 +434,9 @@ LLMCal 是一个强大的 PopClip 扩展，使用 AI 将选定的文本转换为
 
 <div align="center">
   <img src="assets/logo.png" alt="LLMCal Logo" width="200">
-  
+
   <h1>LLMCal - Creador de Eventos de Calendario Impulsado por IA para PopClip</h1>
-  
+
   <a href="https://cafferychen777.github.io/LLMCal/" target="_blank">
     <img src="https://img.shields.io/badge/Demo-Ver-brightgreen" alt="Demo en vivo">
   </a>
@@ -532,9 +587,9 @@ Este proyecto está licenciado bajo la Licencia Pública General de GNU Affero V
 
 <div align="center">
   <img src="assets/logo.png" alt="LLMCal Logo" width="200">
-  
+
   <h1>LLMCal - Créateur d'événements de calendrier alimenté par IA pour PopClip</h1>
-  
+
   <a href="https://cafferychen777.github.io/LLMCal/" target="_blank">
     <img src="https://img.shields.io/badge/Démo-Voir-brightgreen" alt="Démo en direct">
   </a>
@@ -571,9 +626,9 @@ Puis cliquez sur l'icône calendrier dans le menu PopClip.
 
 <div align="center">
   <img src="assets/logo.png" alt="LLMCal Logo" width="200">
-  
+
   <h1>LLMCal - KI-gestützter Kalenderereignis-Creator für PopClip</h1>
-  
+
   <a href="https://cafferychen777.github.io/LLMCal/" target="_blank">
     <img src="https://img.shields.io/badge/Demo-Ansehen-brightgreen" alt="Live-Demo">
   </a>
@@ -610,9 +665,9 @@ Klicken Sie dann auf das Kalendersymbol im PopClip-Menü.
 
 <div align="center">
   <img src="assets/logo.png" alt="LLMCal Logo" width="200">
-  
+
   <h1>LLMCal - PopClip用のAI搭載カレンダーイベントクリエーター</h1>
-  
+
   <a href="https://cafferychen777.github.io/LLMCal/" target="_blank">
     <img src="https://img.shields.io/badge/デモ-表示-brightgreen" alt="ライブデモ">
   </a>

--- a/README.md
+++ b/README.md
@@ -35,16 +35,25 @@
   <a href="https://github.com/cafferychen777/LLMCal/issues">
     <img src="https://img.shields.io/github/issues/cafferychen777/LLMCal" alt="GitHub issues">
   </a>
+  <a href="https://github.com/cafferychen777/LLMCal/discussions">
+    <img src="https://img.shields.io/github/discussions/cafferychen777/LLMCal" alt="GitHub Discussions">
+  </a>
+  <a href="https://github.com/cafferychen777/LLMCal/releases">
+    <img src="https://img.shields.io/github/downloads/cafferychen777/LLMCal/total" alt="Downloads">
+  </a>
   <a href="https://github.com/cafferychen777/LLMCal/blob/main/LICENSE">
     <img src="https://img.shields.io/badge/License-AGPLv3%20with%20Commons%20Clause-blue" alt="License">
   </a>
-  <a href="https://github.com/cafferychen777/LLMCal/releases">
-    <img src="https://img.shields.io/github/v/release/cafferychen777/LLMCal" alt="GitHub release">
+  <a href="https://github.com/cafferychen777/LLMCal/pulls">
+    <img src="https://img.shields.io/badge/PRs-welcome-brightgreen" alt="PRs welcome">
   </a>
   <a href="https://www.popclip.app/">
     <img src="https://img.shields.io/badge/Platform-PopClip-orange" alt="Platform: PopClip (macOS)">
   </a>
 </div>
+
+> Quick Install: Download latest release → Double‑click → Enter API key → Select text → Click calendar icon
+
 
 LLMCal is a powerful PopClip extension that uses AI to convert selected text into calendar events. It understands natural language descriptions and automatically creates events with proper titles, times, locations, meeting links, and reminders.
 ## Table of Contents

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,24 @@
+# Support
+
+If you run into problems or have questions, this guide helps you find the fastest path to resolution.
+
+## Start Here
+- Check README → Troubleshooting section
+- Search existing issues: https://github.com/cafferychen777/LLMCal/issues
+- Review docs in /docs (INSTALLATION, TROUBLESHOOTING, DEVELOPMENT)
+
+## Ask for Help
+- Open a GitHub Issue using the right template (bug report or feature request)
+- Include:
+  - Environment (macOS version, PopClip version)
+  - LLMCal version (release tag)
+  - Steps to reproduce (exact text you selected)
+  - Expected vs actual behavior
+  - Logs if relevant (sanitized)
+
+## Security Issues
+- Do NOT open a public issue. Follow SECURITY.md to report via private advisory.
+
+## Discussions
+- Use GitHub Discussions for Q&A and ideas: https://github.com/cafferychen777/LLMCal/discussions
+

--- a/demo/index.html
+++ b/demo/index.html
@@ -38,6 +38,7 @@
     </script>
   </head>
   <body>
+    <nav style="max-width:880px;margin:12px auto 0;padding:0 16px"><a href="./faq.html">FAQ</a> · <a href="./use-cases.html">Use Cases</a> · <a href="https://github.com/cafferychen777/LLMCal">GitHub</a></nav>
     <div id="root"></div>
     <script type="module" src="./src/main.tsx"></script>
   </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,38 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="./vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>LLMCal Demo</title>
+    <meta name="keywords" content="PopClip, AI, calendar, macOS, Apple Calendar, Google Calendar, reminders, recurring events, Zoom, Teams, Meet, NLP">
+    <meta property="og:locale" content="en_US" />
+    <title>LLMCal Demo — PopClip AI Calendar Extension</title>
+    <meta name="description" content="LLMCal is a PopClip extension that turns natural language into Apple/Google Calendar events with reminders, recurring rules, and meeting link parsing.">
+    <link rel="canonical" href="https://cafferychen777.github.io/LLMCal/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="LLMCal Demo — PopClip AI Calendar Extension" />
+    <meta property="og:description" content="Turn selected text into calendar events. Multilingual, reminders, recurring events, Zoom/Teams/Meet links." />
+    <meta property="og:url" content="https://cafferychen777.github.io/LLMCal/" />
+    <meta property="og:image" content="https://raw.githubusercontent.com/cafferychen777/LLMCal/main/assets/logo.png" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="LLMCal Demo — PopClip AI Calendar Extension" />
+    <meta name="twitter:description" content="Natural-language to calendar events on macOS via PopClip." />
+    <meta name="twitter:image" content="https://raw.githubusercontent.com/cafferychen777/LLMCal/main/assets/og.png" />
+
+    <!-- JSON-LD -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "LLMCal",
+      "operatingSystem": "macOS",
+      "applicationCategory": "Productivity",
+      "description": "PopClip extension that converts selected text into calendar events.",
+      "url": "https://cafferychen777.github.io/LLMCal/",
+      "offers": {"@type":"Offer","price":"0","priceCurrency":"USD"}
+    }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/demo/public/faq.html
+++ b/demo/public/faq.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LLMCal FAQ — PopClip AI Calendar Extension</title>
+    <meta name="description" content="Frequently asked questions about LLMCal, a PopClip extension that turns selected text into calendar events on macOS." />
+    <meta name="keywords" content="LLMCal, PopClip, calendar, FAQ, macOS, reminders, recurring events, Zoom, Teams, Meet" />
+    <link rel="canonical" href="https://cafferychen777.github.io/LLMCal/faq.html" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="LLMCal FAQ — PopClip AI Calendar Extension" />
+    <meta property="og:description" content="Answers to common questions about using LLMCal for creating calendar events from text." />
+    <meta property="og:url" content="https://cafferychen777.github.io/LLMCal/faq.html" />
+    <meta property="og:image" content="https://raw.githubusercontent.com/cafferychen777/LLMCal/main/assets/logo.png" />
+    <meta property="og:locale" content="en_US" />
+    <style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu;max-width:880px;margin:32px auto;padding:0 16px;line-height:1.6}nav a{margin-right:12px}</style>
+  </head>
+  <body>
+    <nav>
+      <a href="./">Home</a>
+      <a href="./use-cases.html">Use Cases</a>
+      <a href="https://github.com/cafferychen777/LLMCal">GitHub</a>
+    </nav>
+    <h1>LLMCal FAQ</h1>
+    <h2>Does LLMCal work with Google Calendar?</h2>
+    <p>Yes. Connect your Google account to Apple Calendar on macOS. Events created via LLMCal sync to Google Calendar automatically.</p>
+    <h2>Can it parse recurring events and reminders?</h2>
+    <p>Yes. It understands common recurring patterns (weekly, monthly, weekdays) and reminder phrases (e.g., “remind me 15 minutes before”).</p>
+    <h2>Does it extract Zoom / Teams / Google Meet links?</h2>
+    <p>Yes. Meeting URLs in the selected text are detected and added to the event.</p>
+    <h2>Which languages are supported?</h2>
+    <p>English, 中文, Español, Français, Deutsch, 日本語.</p>
+    <h2>Which calendar apps are supported?</h2>
+    <p>It operates via Apple Calendar on macOS. Google Calendar is supported through Apple Calendar account integration.</p>
+    <h2>Any privacy concerns?</h2>
+    <p>API keys are stored securely via PopClip. No event data is stored beyond creating the event. See README and SECURITY.md.</p>
+    <h2>Troubleshooting tips?</h2>
+    <ul>
+      <li>Ensure PopClip has Accessibility and Calendar permissions</li>
+      <li>Verify API key is valid and entered in LLMCal options</li>
+      <li>Check internet connection and try again</li>
+      <li>See the full guide in docs/TROUBLESHOOTING.md</li>
+    </ul>
+  </body>
+</html>
+

--- a/demo/public/robots.txt
+++ b/demo/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://cafferychen777.github.io/LLMCal/sitemap.xml
+

--- a/demo/public/sitemap.xml
+++ b/demo/public/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://cafferychen777.github.io/LLMCal/</loc>
+  </url>
+</urlset>
+

--- a/demo/public/use-cases.html
+++ b/demo/public/use-cases.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LLMCal Use Cases — PopClip AI Calendar Extension</title>
+    <meta name="description" content="Practical use cases of LLMCal turning selected text into calendar events." />
+    <meta name="keywords" content="LLMCal, PopClip, calendar, use cases, macOS, reminders, recurring events, Zoom, Teams, Meet" />
+    <link rel="canonical" href="https://cafferychen777.github.io/LLMCal/use-cases.html" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="LLMCal Use Cases — PopClip AI Calendar Extension" />
+    <meta property="og:description" content="Examples showing how to create calendar events from natural language text using LLMCal." />
+    <meta property="og:url" content="https://cafferychen777.github.io/LLMCal/use-cases.html" />
+    <meta property="og:image" content="https://raw.githubusercontent.com/cafferychen777/LLMCal/main/assets/logo.png" />
+    <meta property="og:locale" content="en_US" />
+    <style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu;max-width:880px;margin:32px auto;padding:0 16px;line-height:1.6}nav a{margin-right:12px}</style>
+  </head>
+  <body>
+    <nav>
+      <a href="./">Home</a>
+      <a href="./faq.html">FAQ</a>
+      <a href="https://github.com/cafferychen777/LLMCal">GitHub</a>
+    </nav>
+    <h1>LLMCal Use Cases</h1>
+    <h2>Quick meeting creation from highlighted text</h2>
+    <p>Select: “Team sync tomorrow 2–3pm, Zoom https://zoom.us/j/123, remind me 10 minutes before” → Event with title, time, Zoom link, and reminder.</p>
+    <h2>Recurring events from natural language</h2>
+    <p>Select: “Weekly standup every Mon 9:30am, 30 minutes” → RRULE and duration set.</p>
+    <h2>Parse attendees and locations</h2>
+    <p>Select: “Product demo next Tue 3pm at HQ Boardroom with alice@example.com bob@example.com” → Location and attendees parsed.</p>
+    <h2>Time zones and all‑day events</h2>
+    <p>Select: “1:1 Thursday 10am PST (my time 1pm EST), 30 minutes” / “All-day offsite next Friday”.</p>
+    <h2>Personal productivity</h2>
+    <p>Select: “Pay rent on the 1st of every month, remind me 1 day before”.</p>
+  </body>
+</html>
+

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,26 @@
+# FAQ
+
+## Does LLMCal work with Google Calendar?
+Yes. Connect your Google account to Apple Calendar on macOS. Events created via LLMCal sync to Google Calendar automatically.
+
+## Can it parse recurring events and reminders?
+Yes. It understands common recurring patterns (weekly, monthly, weekdays) and reminder phrases (e.g., "remind me 15 minutes before").
+
+## Does it extract Zoom / Teams / Google Meet links?
+Yes. Meeting URLs in the selected text are detected and added to the event.
+
+## Which languages are supported?
+English, 中文, Español, Français, Deutsch, 日本語.
+
+## Which calendar apps are supported?
+It operates via Apple Calendar on macOS. Google Calendar is supported through Apple Calendar account integration.
+
+## Any privacy concerns?
+API keys are stored securely via PopClip. No event data is stored beyond creating the event. See README and SECURITY.md.
+
+## Troubleshooting tips?
+- Ensure PopClip has Accessibility and Calendar permissions
+- Verify API key is valid and entered in LLMCal options
+- Check internet connection and try again
+- See docs/TROUBLESHOOTING.md for more
+

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -1,0 +1,26 @@
+# Use Cases
+
+## 1) Quick meeting creation from highlighted text
+- Select: "Team sync tomorrow 2–3pm, Zoom https://zoom.us/j/123, remind me 10 minutes before"
+- Result: Event with title, time, Zoom link, and reminder created instantly.
+
+## 2) Recurring events from natural language
+- Select: "Weekly standup every Mon 9:30am, 30 minutes"
+- Result: Recurring event (RRULE) with duration and weekday correctly set.
+
+## 3) Parse attendees and locations
+- Select: "Product demo next Tue 3pm at HQ Boardroom with alice@example.com bob@example.com"
+- Result: Event includes location and attendees.
+
+## 4) Time zones and all‑day events
+- Select: "1:1 Thursday 10am PST (my time 1pm EST), 30 minutes"
+- Select: "All-day offsite next Friday"
+
+## 5) Personal productivity
+- Select: "Pay rent on the 1st of every month, remind me 1 day before"
+
+Tips
+- Use concise, unambiguous expressions for best results
+- Include URLs for Zoom/Teams/Meet when applicable
+- Add attendees via email addresses in the text
+

--- a/package.json
+++ b/package.json
@@ -17,7 +17,12 @@
     "test:setup:verbose": "node tests/setup/auto-config.js --verbose",
     "test:setup:force": "node tests/setup/auto-config.js --force-reinstall"
   },
-  "keywords": ["calendar", "ai", "popclip", "claude", "macos", "automation"],
+  "keywords": [
+    "calendar", "ai", "popclip", "claude", "macos", "automation",
+    "apple calendar", "google calendar", "ics", "rrule", "reminders",
+    "recurring events", "meeting links", "zoom", "microsoft teams", "google meet",
+    "nlp", "natural language", "event parser", "productivity", "popclip extension"
+  ],
   "author": "cafferychen777",
   "license": "AGPL-3.0-with-Commons-Clause",
   "description": "LLMCal - AI-Powered Calendar Event Creator for PopClip",


### PR DESCRIPTION
This PR enhances repository visibility (GitHub search) and external SEO, and improves conversion (install/start).

Highlights
- README
  - Add CI/E2E/Pages badges, Downloads/Discussions/PRs welcome
  - Add Table of Contents, FAQ, Comparison, Community & Support
  - Quick Install CTA to reduce friction
- Demo (GitHub Pages)
  - Add meta description, canonical, Open Graph/Twitter, JSON‑LD
  - Add robots.txt + sitemap.xml
  - New static pages with SEO meta: /faq.html, /use-cases.html, and cross‑links from home
- Community & trust
  - Add CODE_OF_CONDUCT.md, SUPPORT.md, CITATION.cff
- Discovery
  - Expand package.json keywords

Notes
- Pages deploy workflow triggers on push to main (paths: demo/**). New demo pages will go live after merge.
- No dependencies or runtime code changed; docs and static assets only.

After merge (optional)
- Set repo About (Description, Website), Topics, and Social preview image to further boost discovery.



---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author