### PR TITLE
docs(seo): Add Get Started page + sitemap update + demo nav link for better conversion

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -38,7 +38,7 @@
     </script>
   </head>
   <body>
-    <nav style="max-width:880px;margin:12px auto 0;padding:0 16px"><a href="./faq.html">FAQ</a> · <a href="./use-cases.html">Use Cases</a> · <a href="https://github.com/cafferychen777/LLMCal">GitHub</a></nav>
+    <nav style="max-width:880px;margin:12px auto 0;padding:0 16px"><a href="./get-started.html">Get Started</a> · <a href="./faq.html">FAQ</a> · <a href="./use-cases.html">Use Cases</a> · <a href="https://github.com/cafferychen777/LLMCal">GitHub</a></nav>
     <div id="root"></div>
     <script type="module" src="./src/main.tsx"></script>
   </body>

--- a/demo/public/get-started.html
+++ b/demo/public/get-started.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Get Started — LLMCal (PopClip AI Calendar Extension)</title>
+    <meta name="description" content="Get started with LLMCal. Download, install, and create your first calendar event from selected text on macOS." />
+    <meta name="keywords" content="LLMCal, PopClip, get started, install, macOS, calendar, AI, reminders, recurring events" />
+    <link rel="canonical" href="https://cafferychen777.github.io/LLMCal/get-started.html" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Get Started — LLMCal (PopClip AI Calendar Extension)" />
+    <meta property="og:description" content="Download and install LLMCal, then turn selected text into calendar events with one click." />
+    <meta property="og:url" content="https://cafferychen777.github.io/LLMCal/get-started.html" />
+    <meta property="og:image" content="https://raw.githubusercontent.com/cafferychen777/LLMCal/main/assets/logo.png" />
+    <meta property="og:locale" content="en_US" />
+    <style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu;max-width:880px;margin:32px auto;padding:0 16px;line-height:1.6}nav a{margin-right:12px}pre{background:#f6f8fa;padding:12px;border-radius:8px;overflow:auto}</style>
+  </head>
+  <body>
+    <nav>
+      <a href="./">Home</a>
+      <a href="./faq.html">FAQ</a>
+      <a href="./use-cases.html">Use Cases</a>
+      <a href="https://github.com/cafferychen777/LLMCal">GitHub</a>
+    </nav>
+    <h1>Get Started</h1>
+    <ol>
+      <li>Download the latest release: <a href="https://github.com/cafferychen777/LLMCal/releases">Releases</a></li>
+      <li>Double‑click the <code>LLMCal.popclipext.zip</code> file to install</li>
+      <li>Open PopClip → Options → LLMCal → Enter your Anthropic API key → Save</li>
+      <li>Select text describing an event → Click the calendar icon</li>
+    </ol>
+    <h2>First Event Example</h2>
+    <pre>"Team meeting tomorrow at 2pm for 1 hour, Zoom https://zoom.us/j/123, remind me 15 minutes before"</pre>
+    <h2>Troubleshooting</h2>
+    <ul>
+      <li>Ensure PopClip has Accessibility and Calendar permissions</li>
+      <li>Check your API key is valid</li>
+      <li>See <a href="https://github.com/cafferychen777/LLMCal/blob/main/docs/INSTALLATION.md">INSTALLATION</a> and <a href="https://github.com/cafferychen777/LLMCal/blob/main/docs/TROUBLESHOOTING.md">TROUBLESHOOTING</a></li>
+    </ul>
+  </body>
+</html>
+

--- a/demo/public/sitemap.xml
+++ b/demo/public/sitemap.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://cafferychen777.github.io/LLMCal/</loc>
-  </url>
+  <url><loc>https://cafferychen777.github.io/LLMCal/</loc></url>
+  <url><loc>https://cafferychen777.github.io/LLMCal/faq.html</loc></url>
+  <url><loc>https://cafferychen777.github.io/LLMCal/use-cases.html</loc></url>
+  <url><loc>https://cafferychen777.github.io/LLMCal/get-started.html</loc></url>
 </urlset>
 


### PR DESCRIPTION
This PR adds a dedicated Get Started page to the demo site, updates the sitemap, and surfaces a prominent nav link on the demo homepage to reduce friction and improve conversion.

Changes
- demo/public/get-started.html — SEO-friendly page with meta/OG/canonical
- demo/public/sitemap.xml — include new page in sitemap
- demo/index.html — add nav link to Get Started page

Notes
- No code or dependency changes; static content only.
- GitHub Pages will publish the new page after merge.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author